### PR TITLE
Add helm value placeholders to the configmap

### DIFF
--- a/charts/cluster-autoscaler/templates/configmap.yaml
+++ b/charts/cluster-autoscaler/templates/configmap.yaml
@@ -84,18 +84,18 @@ data:
         - address: kind-control-plane
           type: Hostname
         allocatable:
-          cpu: "16"
+          cpu: {{.Values.autoscalerResources.member.cpu}}
           ephemeral-storage: 959786032Ki
           hugepages-1Gi: "0"
           hugepages-2Mi: "0"
-          memory: 32Gi
+          memory: {{.Values.autoscalerResources.member.memory}}
           pods: "110"
         capacity:
-          cpu: "16"
+          cpu: {{.Values.autoscalerResources.member.cpu}}
           ephemeral-storage: 959786032Ki
           hugepages-1Gi: "0"
           hugepages-2Mi: "0"
-          memory: 32Gi
+          memory: {{.Values.autoscalerResources.member.memory}}
           pods: "110"
         conditions:
         - lastHeartbeatTime: "2023-05-31T04:39:58Z"
@@ -202,18 +202,18 @@ data:
         - address: kind-worker
           type: Hostname
         allocatable:
-          cpu: "16"
+          cpu: {{.Values.autoscalerResources.member.cpu}}
           ephemeral-storage: 959786032Ki
           hugepages-1Gi: "0"
           hugepages-2Mi: "0"
-          memory: 32Gi
+          memory: {{.Values.autoscalerResources.member.memory}}
           pods: "110"
         capacity:
-          cpu: "16"
+          cpu: {{.Values.autoscalerResources.member.cpu}}
           ephemeral-storage: 959786032Ki
           hugepages-1Gi: "0"
           hugepages-2Mi: "0"
-          memory: 32Gi
+          memory: {{.Values.autoscalerResources.member.memory}}
           pods: "110"
         conditions:
         - lastHeartbeatTime: "2023-05-31T04:40:17Z"
@@ -320,18 +320,18 @@ data:
         - address: kind-worker2
           type: Hostname
         allocatable:
-          cpu: "16"
+          cpu: {{.Values.autoscalerResources.member.cpu}}
           ephemeral-storage: 959786032Ki
           hugepages-1Gi: "0"
           hugepages-2Mi: "0"
-          memory: 32Gi
+          memory: {{.Values.autoscalerResources.member.memory}}
           pods: "110"
         capacity:
-          cpu: "16"
+          cpu: {{.Values.autoscalerResources.member.cpu}}
           ephemeral-storage: 959786032Ki
           hugepages-1Gi: "0"
           hugepages-2Mi: "0"
-          memory: 32Gi
+          memory: {{.Values.autoscalerResources.member.memory}}
           pods: "110"
         conditions:
         - lastHeartbeatTime: "2023-05-31T04:40:17Z"

--- a/charts/cluster-autoscaler/templates/configmap.yaml
+++ b/charts/cluster-autoscaler/templates/configmap.yaml
@@ -84,18 +84,18 @@ data:
         - address: kind-control-plane
           type: Hostname
         allocatable:
-          cpu: {{.Values.autoscalerResources.member.cpu}}
+          cpu: {{.Values.autoscalerResources.member.cpu | default "12"}}
           ephemeral-storage: 959786032Ki
           hugepages-1Gi: "0"
           hugepages-2Mi: "0"
-          memory: {{.Values.autoscalerResources.member.memory}}
+          memory: {{.Values.autoscalerResources.member.memory | default "32Gi"}}
           pods: "110"
         capacity:
-          cpu: {{.Values.autoscalerResources.member.cpu}}
+          cpu: {{.Values.autoscalerResources.member.cpu | default "12"}}
           ephemeral-storage: 959786032Ki
           hugepages-1Gi: "0"
           hugepages-2Mi: "0"
-          memory: {{.Values.autoscalerResources.member.memory}}
+          memory: {{.Values.autoscalerResources.member.memory | default "32Gi"}}
           pods: "110"
         conditions:
         - lastHeartbeatTime: "2023-05-31T04:39:58Z"
@@ -202,18 +202,18 @@ data:
         - address: kind-worker
           type: Hostname
         allocatable:
-          cpu: {{.Values.autoscalerResources.member.cpu}}
+          cpu: {{.Values.autoscalerResources.member.cpu | default "12"}}
           ephemeral-storage: 959786032Ki
           hugepages-1Gi: "0"
           hugepages-2Mi: "0"
-          memory: {{.Values.autoscalerResources.member.memory}}
+          memory: {{.Values.autoscalerResources.member.memory | default "32Gi"}}
           pods: "110"
         capacity:
-          cpu: {{.Values.autoscalerResources.member.cpu}}
+          cpu: {{.Values.autoscalerResources.member.cpu | default "12"}}
           ephemeral-storage: 959786032Ki
           hugepages-1Gi: "0"
           hugepages-2Mi: "0"
-          memory: {{.Values.autoscalerResources.member.memory}}
+          memory: {{.Values.autoscalerResources.member.memory | default "32Gi"}}
           pods: "110"
         conditions:
         - lastHeartbeatTime: "2023-05-31T04:40:17Z"
@@ -320,18 +320,18 @@ data:
         - address: kind-worker2
           type: Hostname
         allocatable:
-          cpu: {{.Values.autoscalerResources.member.cpu}}
+          cpu: {{.Values.autoscalerResources.member.cpu | default "12"}}
           ephemeral-storage: 959786032Ki
           hugepages-1Gi: "0"
           hugepages-2Mi: "0"
-          memory: {{.Values.autoscalerResources.member.memory}}
+          memory: {{.Values.autoscalerResources.member.memory | default "32Gi"}}
           pods: "110"
         capacity:
-          cpu: {{.Values.autoscalerResources.member.cpu}}
+          cpu: {{.Values.autoscalerResources.member.cpu | default "12"}}
           ephemeral-storage: 959786032Ki
           hugepages-1Gi: "0"
           hugepages-2Mi: "0"
-          memory: {{.Values.autoscalerResources.member.memory}}
+          memory: {{.Values.autoscalerResources.member.memory | default "32Gi"}}
           pods: "110"
         conditions:
         - lastHeartbeatTime: "2023-05-31T04:40:17Z"

--- a/charts/cluster-autoscaler/values.yaml
+++ b/charts/cluster-autoscaler/values.yaml
@@ -379,6 +379,11 @@ resources: {}
   #   cpu: 100m
   #   memory: 300Mi
 
+autoscalerResources:
+  member:
+    cpu: ""
+    memory: ""
+
 # revisionHistoryLimit -- The number of revisions to keep.
 revisionHistoryLimit: 10
 


### PR DESCRIPTION
Using helm placeholders, the changes related to this PR allows the dynamic definition running `helm upgrade`. Each placeholder also define a default value like 12 CPU and 32Gi memory. These parameters located in the configmap may be defined using the `value.yaml`.
Using Helm placeholders, the changes introduced in this PR allow dynamic configuration via `helm upgrade`. Each placeholder also defines a default value, such as 12 CPUs and 32Gi of memory. These parameters, located in the ConfigMap, can also be defined in `values.yaml`.